### PR TITLE
Additional config option for prepending original file name to hashed file name

### DIFF
--- a/grails-app/resourceMappers/org/grails/plugin/cachedresources/HashAndCacheResourceMapper.groovy
+++ b/grails-app/resourceMappers/org/grails/plugin/cachedresources/HashAndCacheResourceMapper.groovy
@@ -59,6 +59,10 @@ class HashAndCacheResourceMapper {
     boolean getFlattenDirs() {
         resourceService.getConfigParamOrDefault('flatten', true)
     }
+
+    boolean getIncludeOriginalFilename() {
+        resourceService.getConfigParamOrDefault('includeOriginalFilename', false)
+    }
     
     /**
      * Renames the given input file in the same directory to be the SHA256 hash of it's contents.
@@ -71,6 +75,11 @@ class HashAndCacheResourceMapper {
         } else {
             newName = SHA256Codec.encode(getBytes(input))
         }
+
+        if (includeOriginalFilename) {
+            newName = "${input.name}-${newName}"
+        }
+
         def parent = flattenDirs ? resourceService.workDir : input.parentFile
         def target = new File(parent, extension ? "${newName}.${extension}" : newName)
 


### PR DESCRIPTION
Hi Marc,

I'm hoping that you could include a new configuration option for prepending a file's original name to the hashed name of the renamed file.

This would be useful for easily identifying the resource from it's URL while also maintaining the cache busting properties of the hashed name.
